### PR TITLE
Create the smaller image based on Alpine Linux 3.8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+LICENSE
+README.md
+requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM docker.io/library/python:2.7.15-alpine3.8
-RUN true \
- && set -x \
- && apk add --no-cache build-base \
- && pip install twisted \
- && apk del build-base \
- && true
-COPY server.py .
+FROM python:2.7-onbuild
+
+USER www-data
+
 EXPOSE 10053
-CMD ["python", "server.py"]
+
+CMD [ "python", "server.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM python:2.7-onbuild
-
-USER www-data
-
+FROM docker.io/library/python:2.7.15-alpine3.8
+RUN true \
+ && set -x \
+ && apk add --no-cache build-base \
+ && pip install twisted \
+ && apk del build-base \
+ && true
+COPY server.py .
 EXPOSE 10053
-
-CMD [ "python", "server.py" ]
+CMD ["python", "server.py"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,11 @@
+FROM docker.io/library/python:2.7.15-alpine3.8
+RUN true \
+ && set -x \
+ && apk add --no-cache build-base \
+ && pip install twisted \
+ && apk del build-base \
+ && true
+USER 1001
+COPY server.py .
+EXPOSE 10053
+CMD ["python", "server.py"]


### PR DESCRIPTION
Hi, I found your software very handy for demo with my customers without any need for Internet (nip.io). But the final image size is very big (711 MB). I tried using Alpine Linux 3.8 instead as the base image and resulting to a smaller image (105 MB). I took the liberty to push my image (based on your repo) to https://hub.docker.com/r/okkyhtf/wildcard-dns-server/ for testing.